### PR TITLE
added workingDirectory and fixed workspaceRoot on parameterFiles

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 This extension provides rich OpenEdge ABL language support for Visual Studio Code. Now you can write and run ABL procedures using the excellent IDE-like interface that Visual Studio Code provides.
 
 ## What's new
+* 0.7.4
+    - Fix workspaceRoot on parameterFiles
+    - Optional configuration: workingDirectory
 * 0.7.3
     - Fix remote/local path mapping while remote debugging
 * 0.7.2
@@ -42,6 +45,7 @@ This extension provides rich OpenEdge ABL language support for Visual Studio Cod
 You can create a local config file for your project named `.openedge.json`, with the following structure:
 ```JSON
 {
+    "workingDirectory": "${workspaceFolder}\\Home",
     "proPath": [
         "c:\\temp",
         "${workspaceFolder}"
@@ -53,7 +57,9 @@ You can create a local config file for your project named `.openedge.json`, with
 }
 ```
 
-`proPath` is optionnal, and the default value is the workspaceRoot (of VSCode).
+`proPath` and `workingDirectory` are optional. Default values:
+- `proPath`: workspaceRoot (of VSCode)
+- `workingDirectory`: folder of active source code 
 
 ### Debugger
 You can use the debugger to connect to a remote running process (assuming it is debug-ready), or run locally with debugger.

--- a/schemas/openedge.schema.json
+++ b/schemas/openedge.schema.json
@@ -29,6 +29,11 @@
       "id": "/properties/proPathMode",
       "title": "proPathMode",
       "type": "string"
+    },
+    "workingDirectory": {
+      "id": "/properties/workingDirectory",
+      "description": "Current working directory (home)",      
+      "type": "string"
     }
   },
   "type": "object"

--- a/src/ablCheckSyntax.ts
+++ b/src/ablCheckSyntax.ts
@@ -38,8 +38,10 @@ export function checkSyntax(filename: string, ablConfig: vscode.WorkspaceConfigu
 			parameterFiles: oeConfig.parameterFiles,
 			batchMode: true,
 			startupProcedure: path.join(__dirname, '../../abl-src/check-syntax.p'),
-			param: filename
+			param: filename,
+			workspaceRoot: vscode.workspace.rootPath
 		});
+		cwd = oeConfig.workingDirectory ? oeConfig.workingDirectory.replace('${workspaceRoot}', vscode.workspace.rootPath).replace('${workspaceFolder}', vscode.workspace.rootPath) : cwd;
 		return new Promise<ICheckResult[]>((resolve, reject) => {
 			cp.execFile(cmd, args, { env: env, cwd: cwd }, (err, stdout, stderr) => {
 				try {

--- a/src/ablRun.ts
+++ b/src/ablRun.ts
@@ -16,8 +16,10 @@ export function run(filename: string, ablConfig: vscode.WorkspaceConfiguration):
 			parameterFiles: oeConfig.parameterFiles,
 			batchMode: true,
 			startupProcedure: path.join(__dirname, '../../abl-src/run.p'),
-			param: filename
-		});
+			param: filename,
+			workspaceRoot: vscode.workspace.rootPath
+		});		
+		cwd = oeConfig.workingDirectory ? oeConfig.workingDirectory.replace('${workspaceRoot}', vscode.workspace.rootPath).replace('${workspaceFolder}', vscode.workspace.rootPath) : cwd;
 		return create(cmd, args, { env: env, cwd: cwd }, outputChannel);
 	});
 }

--- a/src/shared/ablPath.ts
+++ b/src/shared/ablPath.ts
@@ -24,12 +24,16 @@ export interface ProArgsOptions {
     batchMode?: boolean;
     debugPort?: number;
     temporaryDirectory?: string;
+    workspaceRoot?: string;
 }
 export function createProArgs(options: ProArgsOptions): string[] {
     let pfArgs = [];
     if (options.parameterFiles) {
         // pfArgs = openEdgeConfig.parameterFiles.filter(pf => pf.trim().length > 0).map(pf => { return '-pf ' + pf; });
         pfArgs = options.parameterFiles.filter(pf => pf.trim().length > 0).reduce((r, a) => r.concat('-pf', a), []);
+        for(let i=0;i<pfArgs.length;i++){
+            pfArgs[i] = pfArgs[i].replace('${workspaceRoot}', options.workspaceRoot);
+        }
     }
     let args = [
         '-T' // Redirect temp

--- a/src/shared/openEdgeConfigFile.ts
+++ b/src/shared/openEdgeConfigFile.ts
@@ -24,6 +24,7 @@ export interface OpenEdgeConfig {
     proPath?: string[];
     proPathMode?: 'append' | 'overwrite' | 'prepend';
     parameterFiles?: string[];
+    workingDirectory?: string;
     test?: TestConfig;
 }
 


### PR DESCRIPTION
Added workingDirectory, current working directory (cwd) for executable.

Added possibility to use ${workspaceRoot} variable in parameterFiles.