### PR TITLE
OpenEdge Startup Procedure

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,19 @@ You can create a local config file for your project named `.openedge.json`, with
     "proPathMode": "append", // overwrite, prepend
     "parameterFiles": [ // -pf
         "default.pf"
-    ]
+    ],
+    "oeStartupProcedure" : "${workspaceFolder}/vsc-oe-startup.p"
 }
 ```
 
-`dlc`, `proPath` and `workingDirectory` are optional. Default values:
+`dlc`, `oeStartupProcedure`, `proPath` and `workingDirectory` are optional. Default values:
 - `dlc`: uses environment variable $DLC
+- `oeStartupProcedure`: ''
 - `proPath`: workspaceRoot (of VSCode)
 - `workingDirectory`: folder of active source code
+
+## Parameter "oeStartupProcedure"
+The optional Startup Procedure for OpenEdge can be used to execute 4GL code before a check syntax/debug/run operation. Can be used to create Database aliases or instantiate Singleton Classes. The Procedure is executed everytime the IDE starts a check syntax/debug/run operation.
 
 ### Debugger
 You can use the debugger to connect to a remote running process (assuming it is debug-ready), or run locally with debugger.

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ You can create a local config file for your project named `.openedge.json`, with
 - `proPath`: workspaceRoot (of VSCode)
 - `workingDirectory`: folder of active source code
 
-## Parameter "oeStartupProcedure"
+#### Parameter "oeStartupProcedure"
 The optional Startup Procedure for OpenEdge can be used to execute 4GL code before a check syntax/debug/run operation. Can be used to create Database aliases or instantiate Singleton Classes. The Procedure is executed everytime the IDE starts a check syntax/debug/run operation.
 
 ### Debugger

--- a/README.md
+++ b/README.md
@@ -37,17 +37,17 @@ You can create a local config file for your project named `.openedge.json`, with
     "parameterFiles": [ // -pf
         "default.pf"
     ],
-    "oeStartupProcedure" : "${workspaceFolder}/vsc-oe-startup.p"
+    "startupProcedure" : "${workspaceFolder}/vsc-oe-startup.p"
 }
 ```
 
-`dlc`, `oeStartupProcedure`, `proPath` and `workingDirectory` are optional. Default values:
+`dlc`, `startupProcedure`, `proPath` and `workingDirectory` are optional. Default values:
 - `dlc`: uses environment variable $DLC
-- `oeStartupProcedure`: ''
+- `startupProcedure`: ''
 - `proPath`: workspaceRoot (of VSCode)
 - `workingDirectory`: folder of active source code
 
-#### Parameter "oeStartupProcedure"
+#### Parameter "startupProcedure"
 The optional Startup Procedure for OpenEdge can be used to execute 4GL code before a check syntax/debug/run operation. Can be used to create Database aliases or instantiate Singleton Classes. The Procedure is executed everytime the IDE starts a check syntax/debug/run operation.
 
 ### Debugger

--- a/abl-src/check-syntax.p
+++ b/abl-src/check-syntax.p
@@ -7,6 +7,11 @@ ASSIGN ch_prog = ENTRY( 1, SESSION:PARAMETER ).
 
 RUN VALUE( REPLACE( PROGRAM-NAME( 1 ), "check-syntax.p", "read-env-var.p") ).
 
+/* OpenEdge Startup Procedure */
+DEFINE VARIABLE vsabl_oe_startup_procedure AS CHARACTER NO-UNDO.
+vsabl_oe_startup_procedure = OS-GETENV ( "VSABL_OE_STARTUP_PROCEDURE" ).
+IF LENGTH( vsabl_oe_startup_procedure ) > 0 THEN RUN VALUE( vsabl_oe_startup_procedure ).
+
 /* Compile without saving */
 COMPILE VALUE( ch_prog ) SAVE=NO NO-ERROR.
 

--- a/abl-src/run-debug.p
+++ b/abl-src/run-debug.p
@@ -10,6 +10,11 @@ end.
 
 RUN VALUE( REPLACE( PROGRAM-NAME( 1 ), "run-debug.p", "read-env-var.p") ).
 
+/* OpenEdge Startup Procedure */
+DEFINE VARIABLE vsabl_oe_startup_procedure AS CHARACTER NO-UNDO.
+vsabl_oe_startup_procedure = OS-GETENV ( "VSABL_OE_STARTUP_PROCEDURE" ).
+IF LENGTH( vsabl_oe_startup_procedure ) > 0 THEN RUN VALUE( vsabl_oe_startup_procedure ).
+
 /* We have to wait for the debugger to connect to this process and set up breakpoints
 When ready, the host sends a key input
 READKEY is the easiest way I found to pause and wait for a signal from the host */

--- a/abl-src/run.p
+++ b/abl-src/run.p
@@ -5,5 +5,10 @@ ASSIGN ch_prog = ENTRY( 1, SESSION:PARAMETER ).
 
 RUN VALUE( REPLACE( PROGRAM-NAME( 1 ), "run.p", "read-env-var.p") ).
 
+/* OpenEdge Startup Procedure */
+DEFINE VARIABLE vsabl_oe_startup_procedure AS CHARACTER NO-UNDO.
+vsabl_oe_startup_procedure = OS-GETENV ( "VSABL_OE_STARTUP_PROCEDURE" ).
+IF LENGTH( vsabl_oe_startup_procedure ) > 0 THEN RUN VALUE( vsabl_oe_startup_procedure ).
+
 /* RUN */
 RUN VALUE( ch_prog ).

--- a/schemas/openedge.schema.json
+++ b/schemas/openedge.schema.json
@@ -40,8 +40,8 @@
       "description": "Current working directory (home)",
       "type": "string"
     },
-    "oeStartupProcedure": {
-      "id": "/properties/oeStartupProcedure",
+    "startupProcedure": {
+      "id": "/properties/startupProcedure",
       "description": "Path to OpenEdge Startup Procedure",
       "type": "string"
     }

--- a/schemas/openedge.schema.json
+++ b/schemas/openedge.schema.json
@@ -39,6 +39,11 @@
       "id": "/properties/workingDirectory",
       "description": "Current working directory (home)",
       "type": "string"
+    },
+    "oeStartupProcedure": {
+      "id": "/properties/oeStartupProcedure",
+      "description": "Path to OpenEdge Startup Procedure",
+      "type": "string"
     }
   },
   "type": "object"

--- a/src/shared/ablPath.ts
+++ b/src/shared/ablPath.ts
@@ -81,6 +81,13 @@ export function setupEnvironmentVariables(env: any, openEdgeConfig: OpenEdgeConf
         } else {
             env.VSABL_PROPATH_MODE = 'append';
         }
+
+        if (openEdgeConfig.oeStartupProcedure) {
+            env.VSABL_OE_STARTUP_PROCEDURE = openEdgeConfig.oeStartupProcedure.replace('${workspaceRoot}', workspaceRoot).replace('${workspaceFolder}', workspaceRoot);
+        } else {
+            // unset var; required in case user changes config
+            env.VSABL_OE_STARTUP_PROCEDURE = '';
+        }
     }
     env.VSABL_SRC = path.join(__dirname, '../../abl-src');
     // enable the debugger

--- a/src/shared/ablPath.ts
+++ b/src/shared/ablPath.ts
@@ -82,8 +82,8 @@ export function setupEnvironmentVariables(env: any, openEdgeConfig: OpenEdgeConf
             env.VSABL_PROPATH_MODE = 'append';
         }
 
-        if (openEdgeConfig.oeStartupProcedure) {
-            env.VSABL_OE_STARTUP_PROCEDURE = openEdgeConfig.oeStartupProcedure.replace('${workspaceRoot}', workspaceRoot).replace('${workspaceFolder}', workspaceRoot);
+        if (openEdgeConfig.startupProcedure) {
+            env.VSABL_OE_STARTUP_PROCEDURE = openEdgeConfig.startupProcedure.replace('${workspaceRoot}', workspaceRoot).replace('${workspaceFolder}', workspaceRoot);
         } else {
             // unset var; required in case user changes config
             env.VSABL_OE_STARTUP_PROCEDURE = '';

--- a/src/shared/openEdgeConfigFile.ts
+++ b/src/shared/openEdgeConfigFile.ts
@@ -27,6 +27,7 @@ export interface OpenEdgeConfig {
     parameterFiles?: string[];
     workingDirectory?: string;
     test?: TestConfig;
+    oeStartupProcedure?: string;
 }
 
 export function loadConfigFile(filename: string): Thenable<OpenEdgeConfig> {

--- a/src/shared/openEdgeConfigFile.ts
+++ b/src/shared/openEdgeConfigFile.ts
@@ -27,7 +27,7 @@ export interface OpenEdgeConfig {
     parameterFiles?: string[];
     workingDirectory?: string;
     test?: TestConfig;
-    oeStartupProcedure?: string;
+    startupProcedure?: string;
 }
 
 export function loadConfigFile(filename: string): Thenable<OpenEdgeConfig> {


### PR DESCRIPTION
This introduces a new optional Parameter in the Config File (oeStartupProcedure), allowing the User to executed his own code before check syntax, debug or run is executed. I use this to create Database aliases and instantiate singleton classes.

example:
.openedge.json
{ "oeStartupProcedure" : "${workspaceFolder}/set-user.p" }

set-user.p:
/* set the user */
DEF VAR c_imas AS Wawi.Imas .
c_conf = System.Configuration:Instanz .
c_conf:set_user("developer") .
/* do whatever you want */