### PR TITLE
fix temporaryDirectory is undefined

### DIFF
--- a/src/shared/ablPath.ts
+++ b/src/shared/ablPath.ts
@@ -41,13 +41,14 @@ export function createProArgs(options: ProArgsOptions): string[] {
             pfArgs[i] = pfArgs[i].replace('${workspaceRoot}', options.workspaceRoot);
         }
     }
-    let args = [
-        '-T', // Redirect temp
-    ];
-    if (options.temporaryDirectory) {
-        args.push(options.temporaryDirectory);
-    } else {
-        args.push(process.env.TEMP);
+    let args = [];
+    let tempDir = options.temporaryDirectory;
+    if (!tempDir) {
+        tempDir = process.env.TEMP;
+    }
+    if (tempDir) {
+        args.push('-T');
+        args.push(tempDir);
     }
     args = args.concat(pfArgs);
     if (options.batchMode) {


### PR DESCRIPTION
temporaryDirectory is undefined when calling checkSyntax if there's no TEMP environment variable is set.