### PR TITLE
support prowin as checkSyntaxWindowExecutable

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,17 +26,19 @@ You can create a local config file for your project named `.openedge.json`, with
         "${workspaceFolder}"
     ],
     "dlc": "C:/Progress/OpenEdge", //optional override
-    "proPathMode": "append", // overwrite, prepend
+    "proPathMode": "append", // append, overwrite, prepend
     "parameterFiles": [ // -pf
         "default.pf"
     ],
+    "initializationFile": "default.ini", // -ininame
     "startupProcedure" : "${workspaceFolder}/vsc-oe-startup.p",
     "dbDictionary": [
         "myDatabaseForAutoComplete"
     ],
     "format": {
-        "trim": "right" // none
-    }
+        "trim": "right" // right, none
+    },
+    "checkSyntaxWindowExecutable": "prowin" // prowin, _progres
 }
 ```
 

--- a/schemas/openedge.schema.json
+++ b/schemas/openedge.schema.json
@@ -1,55 +1,64 @@
 {
-  "definitions": {},
-  "id": "openedge.json",
-  "properties": {
-    "parameterFiles": {
-      "id": "/properties/parameterFiles",
-      "description": "Path to .pf files",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
+    "definitions": {},
+    "id": "openedge.json",
+    "properties": {
+        "parameterFiles": {
+            "id": "/properties/parameterFiles",
+            "description": "Path to .pf files",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "initializationFile": {
+            "id": "/properties/initializationFile",
+            "description": "Path to .ini file",
+            "type": "string"
+        },
+        "dlc": {
+            "id": "/properties/dlc",
+            "description": "Path to Progress OpenEdge installation (if not set use ENVVAR $DLC)",
+            "type": "string"
+        },
+        "proPath": {
+            "id": "/properties/proPath",
+            "description": "Path to include in the PROPATH variable",
+            "items": {
+                "type": "string"
+            },
+            "type": "array"
+        },
+        "proPathMode": {
+            "default": "append",
+            "description": "Specify how the PROPATH is modified",
+            "enum": ["append", "prepend", "overwrite"],
+            "id": "/properties/proPathMode",
+            "title": "proPathMode",
+            "type": "string"
+        },
+        "checkSyntaxWindowExecutable": {
+            "default": "prowin",
+            "description": "Specify executable to check syntax for window (.w) application",
+            "enum": ["prowin", "_progres"],
+            "id": "/properties/checkSyntaxWindowExecutable",
+            "title": "checkSyntaxWindowExecutable",
+            "type": "string"
+        },
+        "workingDirectory": {
+            "id": "/properties/workingDirectory",
+            "description": "Current working directory (home)",
+            "type": "string"
+        },
+        "startupProcedure": {
+            "id": "/properties/startupProcedure",
+            "description": "Path to OpenEdge Startup Procedure",
+            "type": "string"
+        },
+        "dbDictionary": {
+            "id": "/properties/dbDictionary",
+            "description": "Logical names of database files for the auto-complete option (command: ABL Read Dictionary Structure)",
+            "type": "array"
+        }
     },
-    "dlc": {
-      "id": "/properties/dlc",
-      "description": "Path to Progress OpenEdge installation (if not set use ENVVAR $DLC)",
-      "type": ["string", "array"]
-    },
-    "proPath": {
-      "id": "/properties/proPath",
-      "description": "Path to include in the PROPATH variable",
-      "items": {
-        "type": "string"
-      },
-      "type": "array"
-    },
-    "proPathMode": {
-      "default": "append",
-      "description": "Specify how the PROPATH is modified",
-      "enum": [
-        "append",
-        "prepend",
-        "overwrite"
-      ],
-      "id": "/properties/proPathMode",
-      "title": "proPathMode",
-      "type": "string"
-    },
-    "workingDirectory": {
-      "id": "/properties/workingDirectory",
-      "description": "Current working directory (home)",
-      "type": "string"
-    },
-    "startupProcedure": {
-      "id": "/properties/startupProcedure",
-      "description": "Path to OpenEdge Startup Procedure",
-      "type": "string"
-    },
-    "dbDictionary": {
-      "id": "/properties/dbDictionary",
-      "description": "Logical names of database files for the auto-complete option (command: ABL Read Dictionary Structure)",
-      "type": "array"
-    }
-  },
-  "type": "object"
+    "type": "object"
 }

--- a/src/ablCheckSyntax.ts
+++ b/src/ablCheckSyntax.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { getOpenEdgeConfig } from './ablConfig';
 import { outputChannel } from './ablStatus';
-import { createProArgs, getProBin, setupEnvironmentVariables } from './shared/ablPath';
+import { createProArgs, getProBin, getProwinBin, setupEnvironmentVariables } from './shared/ablPath';
 
 const statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left);
 // statusBarItem.command = 'abl.checkSyntax.showOutput';
@@ -30,12 +30,17 @@ export function checkSyntax(filename: string, ablConfig: vscode.WorkspaceConfigu
     let cwd = path.dirname(filename);
 
     return getOpenEdgeConfig().then((oeConfig) => {
-        const cmd = getProBin(oeConfig.dlc);
+        let cmd = "";
+        let regWindowFile = /^.*\.w$/
+        if (filename.match(regWindowFile) && oeConfig.checkSyntaxWindowExecutable != '_progres')
+            cmd = getProwinBin(oeConfig.dlc);
+        else cmd = getProBin(oeConfig.dlc);
         const env = setupEnvironmentVariables(process.env, oeConfig, vscode.workspace.rootPath);
         const args = createProArgs({
             batchMode: true,
             param: filename,
             parameterFiles: oeConfig.parameterFiles,
+            initializationFile: oeConfig.initializationFile,
             startupProcedure: path.join(__dirname, '../../abl-src/check-syntax.p'),
             workspaceRoot: vscode.workspace.rootPath,
         });

--- a/src/ablRun.ts
+++ b/src/ablRun.ts
@@ -16,6 +16,7 @@ export function run(filename: string, ablConfig: vscode.WorkspaceConfiguration):
             batchMode: true,
             param: filename,
             parameterFiles: oeConfig.parameterFiles,
+            initializationFile: oeConfig.initializationFile,
             startupProcedure: path.join(__dirname, '../../abl-src/run.p'),
             workspaceRoot: vscode.workspace.rootPath,
         });

--- a/src/ablTest.ts
+++ b/src/ablTest.ts
@@ -87,6 +87,7 @@ async function runTestFile(fileName, cmd, env, cwd, oeConfig: OpenEdgeConfig) {
         batchMode: true,
         param: `${fileName} -outputLocation ${outDir}`,
         parameterFiles: oeConfig.parameterFiles,
+        initializationFile: oeConfig.initializationFile,
         startupProcedure: 'ABLUnitCore.p',
         temporaryDirectory: outDir,
     });

--- a/src/debugAdapter/ablDebug.ts
+++ b/src/debugAdapter/ablDebug.ts
@@ -351,6 +351,7 @@ class AblDebugSession extends DebugSession {
                 debugPort: args.port,
                 param: args.args ? args.args.join(' ') : '',
                 parameterFiles: oeConfig.parameterFiles,
+                initializationFile: oeConfig.initializationFile,
                 startupProcedure: path.join(__dirname, '../../../abl-src/run-debug.p'),
             });
 

--- a/src/parser/documentController.ts
+++ b/src/parser/documentController.ts
@@ -415,7 +415,7 @@ export class ABLDocument {
         this._temps = getAllTempTables(sourceCode);
         // reference to db tables
         this._temps.filter((item) => !isNullOrUndefined(item.referenceTable)).forEach((item) => {
-            const tb = getTableCollection().items.find((tn) => tn.label.toLowerCase() === item.referenceTable.toLowerCase());
+            const tb = getTableCollection().items.find((tn) => tn.label.toString().toLowerCase() === item.referenceTable.toLowerCase());
             // tslint:disable-next-line:no-string-literal
             if ((!isNullOrUndefined(tb)) && (!isNullOrUndefined(tb['fields']))) {
                 // tslint:disable-next-line:no-string-literal
@@ -472,7 +472,7 @@ export class ABLDocumentController {
         if (document.languageId === ABL_MODE.language) {
             const ablDoc: ABLDocument = this._documents[document.uri.fsPath];
             const invoke = this.invokeUpdateDocument;
-            return new Promise((resolve, reject) => {
+            return new Promise<null | void>((resolve, reject) => {
                 if (ablDoc) {
                     // cancel any pending update request
                     if (ablDoc.debounceController) {

--- a/src/providers/ablCompletionProvider.ts
+++ b/src/providers/ablCompletionProvider.ts
@@ -88,7 +88,7 @@ export class ABLCompletionItemProvider implements vscode.CompletionItemProvider 
 
     private getCompletionFields(prefix: string, replacement?: string): vscode.CompletionItem[] {
         // Tables
-        const tb = _tableCollection.items.find((item) => item.label.toLowerCase() === prefix);
+        const tb = _tableCollection.items.find((item) => item.label.toString().toLowerCase() === prefix);
         if (tb) {
             // tslint:disable-next-line:no-string-literal
             let result = tb['completion'].items;
@@ -146,7 +146,7 @@ function unloadDumpFile(filename: string) {
 }
 
 export function watchDictDumpFiles() {
-    return new Promise<null>((resolve, reject) => {
+    return new Promise<null | void>((resolve, reject) => {
         watcher = vscode.workspace.createFileSystemWatcher('**/.openedge.db.*');
         watcher.onDidChange((uri) => loadAndSetDumpFile(uri.fsPath));
         watcher.onDidDelete((uri) => unloadDumpFile(uri.fsPath));

--- a/src/providers/ablHoverProvider.ts
+++ b/src/providers/ablHoverProvider.ts
@@ -30,7 +30,7 @@ export class ABLHoverProvider implements HoverProvider {
             if ((words.length === 1) ||
                 ((words.length > 1) && (selection.word === words[0]))) {
                 // check for table collection
-                const tb = getTableCollection().items.find((item) => item.label.toLocaleLowerCase() === selection.word);
+                const tb = getTableCollection().items.find((item) => item.label.toString().toLocaleLowerCase() === selection.word);
                 if (tb) {
                     const tbd = tb as ABLTableDefinition;
                     return new Hover([selection.word, '*' + tb.detail + '*', 'PK: ' + tbd.pkList], selection.wordRange);

--- a/src/shared/ablPath.ts
+++ b/src/shared/ablPath.ts
@@ -41,6 +41,7 @@ export interface ProArgsOptions {
     startupProcedure: string;
     param?: string;
     parameterFiles?: string[];
+    initializationFile?: string;
     databaseNames?: string[];
     batchMode?: boolean;
     debugPort?: number;
@@ -69,6 +70,9 @@ export function createProArgs(options: ProArgsOptions): string[] {
     if (tempDir) {
         args.push('-T');
         args.push(tempDir);
+    }
+    if(options.initializationFile){
+        args.push('-ininame', options.initializationFile.replace('${workspaceRoot}', options.workspaceRoot));
     }
     args = args.concat(pfArgs);
     if (options.batchMode) {

--- a/src/shared/openEdgeConfigFile.ts
+++ b/src/shared/openEdgeConfigFile.ts
@@ -26,11 +26,13 @@ export interface OpenEdgeConfig {
     proPath?: string[];
     proPathMode?: 'append' | 'overwrite' | 'prepend';
     parameterFiles?: string[];
+    initializationFile?: string,
     workingDirectory?: string;
     test?: TestConfig;
     startupProcedure?: string;
     dbDictionary?: string[];
     format?: OpenEdgeFormatOptions;
+    checkSyntaxWindowExecutable?: 'prowin' | '_progres';
 }
 
 export function loadConfigFile(filename: string): Thenable<OpenEdgeConfig> {


### PR DESCRIPTION
Relates to #24 and #64.

You can now specify initializationFile (ininame) and checkSyntaxWindowExecutable (.w) to be prowin instead of _progres.